### PR TITLE
fix(gitlab): Use gitlab platform token to authenticate against gitlab composer package registry

### DIFF
--- a/lib/constants/platforms.ts
+++ b/lib/constants/platforms.ts
@@ -22,6 +22,7 @@ export const GITLAB_API_USING_HOST_TYPES = [
   'gitlab-tags',
   'gitlab-packages',
   'gitlab-changelog',
+  'packagist',
 ];
 
 export const BITBUCKET_API_USING_HOST_TYPES = [

--- a/lib/constants/platforms.ts
+++ b/lib/constants/platforms.ts
@@ -29,3 +29,12 @@ export const BITBUCKET_API_USING_HOST_TYPES = [
   PlatformId.Bitbucket,
   'bitbucket-tags',
 ];
+
+export const platformHostTypes = {
+  [PlatformId.Azure]: [],
+  [PlatformId.Bitbucket]: BITBUCKET_API_USING_HOST_TYPES,
+  [PlatformId.BitbucketServer]: [],
+  [PlatformId.Gitea]: [],
+  [PlatformId.Github]: GITHUB_API_USING_HOST_TYPES,
+  [PlatformId.Gitlab]: GITLAB_API_USING_HOST_TYPES,
+};

--- a/lib/platform/index.ts
+++ b/lib/platform/index.ts
@@ -1,6 +1,6 @@
 import URL from 'url';
 import type { AllConfig } from '../config/types';
-import { PlatformId } from '../constants';
+import { platformHostTypes } from '../constants';
 import { PLATFORM_NOT_FOUND } from '../constants/error-messages';
 import { id as packagistDatasourceId } from '../datasource/packagist';
 import { logger } from '../logger';
@@ -72,7 +72,9 @@ export async function initPlatform(config: AllConfig): Promise<AllConfig> {
   };
   returnConfig.hostRules.push(typedPlatformRule);
   hostRules.add(typedPlatformRule);
-  if ([PlatformId.Gitlab].includes(returnConfig.platform)) {
+  // Some platforms additionally provide a private composer package registry
+  const hostTypes = platformHostTypes[returnConfig.platform];
+  if (hostTypes.includes(packagistDatasourceId)) {
     const typedPackageRegistryRule = {
       ...platformRule,
       hostType: packagistDatasourceId,

--- a/lib/platform/index.ts
+++ b/lib/platform/index.ts
@@ -1,6 +1,8 @@
 import URL from 'url';
 import type { AllConfig } from '../config/types';
+import { PlatformId } from '../constants';
 import { PLATFORM_NOT_FOUND } from '../constants/error-messages';
+import { id as packagistDatasourceId } from '../datasource/packagist';
 import { logger } from '../logger';
 import type { HostRule } from '../types';
 import { setGitAuthor, setNoVerify, setPrivateKey } from '../util/git';
@@ -70,5 +72,13 @@ export async function initPlatform(config: AllConfig): Promise<AllConfig> {
   };
   returnConfig.hostRules.push(typedPlatformRule);
   hostRules.add(typedPlatformRule);
+  if ([PlatformId.Gitlab].includes(returnConfig.platform)) {
+    const typedPackageRegistryRule = {
+      ...platformRule,
+      hostType: packagistDatasourceId,
+    };
+    returnConfig.hostRules.push(typedPackageRegistryRule);
+    hostRules.add(typedPackageRegistryRule);
+  }
   return returnConfig;
 }


### PR DESCRIPTION
## Changes:

This patch applies the configured gitlab platform token to 'packagist' contexts. This way, self-hosted gitlab package registries are used as intended.

## Context:

Previous to this patch, self hosted gitlab composer package registries were silently skipped after gitlab would have responded with a "404 Group Not Found".

## Fixes:

Closes #10649

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
